### PR TITLE
Create issues for DigiPol from the Flux Discord

### DIFF
--- a/flux-projects/cogs/issue.py
+++ b/flux-projects/cogs/issue.py
@@ -13,7 +13,7 @@ class Issue(commands.Cog):
 
     @commands.command(brief='Create a new issue for DigiPol', help='Create a new issue for the app. You will be prompted to answer some questions by the bot.')
     @commands.max_concurrency(1, per=BucketType.user, wait=False)
-    @commands.has_role('Flux Vetted')
+    @commands.has_role('App Issue Creator')
     async def issue(self, ctx):
         await ctx.message.delete()
 

--- a/flux-projects/cogs/issue.py
+++ b/flux-projects/cogs/issue.py
@@ -2,6 +2,7 @@ import discord
 from discord.ext import commands
 from discord.ext.commands.cooldowns import BucketType
 from discord.utils import get
+import requests
 
 
 class Issue(commands.Cog):

--- a/flux-projects/cogs/issue.py
+++ b/flux-projects/cogs/issue.py
@@ -28,6 +28,10 @@ class Issue(commands.Cog):
         qhand = self.flux.get_cog('Question')
         ans = await qhand.question_handler(ctx.author, questions)
 
+        # Last value of ans will be True if all questions were asked
+        if len(ans) == 0 or ans[-1] != True:
+            return
+
 
 def setup(flux):
     flux.add_cog(Issue(flux))

--- a/flux-projects/cogs/issue.py
+++ b/flux-projects/cogs/issue.py
@@ -8,7 +8,6 @@ class Issue(commands.Cog):
 
     def __init__(self, flux):
         self.flux = flux
-        self.question = self.flux.get_cog('Question')
 
     @commands.command(brief='Create a new issue for DigiPol', help='Create a new issue for the app. You will be prompted to answer some questions by the bot.')
     @commands.max_concurrency(1, per=BucketType.user, wait=False)
@@ -26,7 +25,8 @@ class Issue(commands.Cog):
                     ['text', 'What is the description of your issue?', 256],
                     ['text', 'What is the name of the sponsoring organisation?', 64]]
         
-        ans = await self.question.question_handler(ctx.author, questions)
+        qhand = self.flux.get_cog('Question')
+        ans = await qhand.question_handler(ctx.author, questions)
 
 
 def setup(flux):

--- a/flux-projects/cogs/issue.py
+++ b/flux-projects/cogs/issue.py
@@ -19,7 +19,7 @@ class Issue(commands.Cog):
         embed = discord.Embed(description='You\'re now creating a new issue for the app, here is what I need to know from you:', colour=discord.Colour.green())
         await ctx.author.send(embed=embed)
 
-        questions = [['text', 'What is the title if your issue?', 64],
+        questions = [['text', 'What is the title of your issue?', 64],
                     ['date', 'What is the start date of your issue?'],
                     ['date', 'What is the end date of your issue?'],
                     ['text', 'What is the question of your issue?', 128],

--- a/flux-projects/cogs/issue.py
+++ b/flux-projects/cogs/issue.py
@@ -49,7 +49,7 @@ class Issue(commands.Cog):
         resp = requests.post('https://1j56c60pb0.execute-api.ap-southeast-2.amazonaws.com/dev/issue', json=issue)
 
         # Raise an error if we don't get an OK response
-        if resp.status_code != 201:
+        if resp.status_code != 200:
             raise commands.CommandError(f'POST /dev/issue {resp.status_code}')
 
         embed = discord.Embed(description='You have successfully created a new issue for the app.', colour=discord.Colour.green())

--- a/flux-projects/cogs/issue.py
+++ b/flux-projects/cogs/issue.py
@@ -32,6 +32,9 @@ class Issue(commands.Cog):
         if len(ans) == 0 or ans[-1] != True:
             return
 
+        embed = discord.Embed(description='You have successfully created a new issue for the app.', colour=discord.Colour.green())
+        await ctx.author.send(embed=embed)
+
 
 def setup(flux):
     flux.add_cog(Issue(flux))

--- a/flux-projects/cogs/issue.py
+++ b/flux-projects/cogs/issue.py
@@ -44,6 +44,13 @@ class Issue(commands.Cog):
                     "description": ans[3],
                     "sponsor": ans[4]}}
         
+        # Make the API POST request
+        resp = requests.post('https://1j56c60pb0.execute-api.ap-southeast-2.amazonaws.com/dev/issue', json=issue)
+
+        # Raise an error if we don't get an OK response
+        if resp.status_code != 201:
+            raise commands.CommandError(f'POST /dev/issue {resp.status_code}')
+
         embed = discord.Embed(description='You have successfully created a new issue for the app.', colour=discord.Colour.green())
         await ctx.author.send(embed=embed)
 

--- a/flux-projects/cogs/issue.py
+++ b/flux-projects/cogs/issue.py
@@ -41,8 +41,9 @@ class Issue(commands.Cog):
                     "short_title": ans[0],
                     "start_date": str(ans[1]),
                     "end_date": str(ans[2]),
-                    "description": ans[3],
-                    "sponsor": ans[4]}}
+                    "question": ans[3],
+                    "description": ans[4],
+                    "sponsor": ans[5]}}
         
         # Make the API POST request
         resp = requests.post('https://1j56c60pb0.execute-api.ap-southeast-2.amazonaws.com/dev/issue', json=issue)

--- a/flux-projects/cogs/issue.py
+++ b/flux-projects/cogs/issue.py
@@ -3,6 +3,7 @@ from discord.ext import commands
 from discord.ext.commands.cooldowns import BucketType
 from discord.utils import get
 import requests
+import utility.config_manager as config
 
 
 class Issue(commands.Cog):
@@ -33,6 +34,16 @@ class Issue(commands.Cog):
         if len(ans) == 0 or ans[-1] != True:
             return
 
+        # Form dictionary for API request
+        issue = {
+            "token": config.read(('Bot', 'issue_token')),
+            "data": {"chamber": "Public",
+                    "short_title": ans[0],
+                    "start_date": str(ans[1]),
+                    "end_date": str(ans[2]),
+                    "description": ans[3],
+                    "sponsor": ans[4]}}
+        
         embed = discord.Embed(description='You have successfully created a new issue for the app.', colour=discord.Colour.green())
         await ctx.author.send(embed=embed)
 

--- a/flux-projects/cogs/issue.py
+++ b/flux-projects/cogs/issue.py
@@ -19,12 +19,12 @@ class Issue(commands.Cog):
         embed = discord.Embed(description='You\'re now creating a new issue for the app, here is what I need to know from you:', colour=discord.Colour.green())
         await ctx.author.send(embed=embed)
 
-        questions = [['text', 'What is the title of your issue?', 64],
+        questions = [['text', 'What is the title of your issue?', 256],
                     ['date', 'What is the start date of your issue?'],
                     ['date', 'What is the end date of your issue?'],
-                    ['text', 'What is the question of your issue?', 128],
+                    ['text', 'What is the question of your issue?', 256],
                     ['text', 'What is the description of your issue?', 256],
-                    ['text', 'What is the name of the sponsoring organisation?', 64]]
+                    ['text', 'What is the name of the sponsoring organisation?', 256]]
         
         qhand = self.flux.get_cog('Question')
         ans = await qhand.question_handler(ctx.author, questions)

--- a/flux-projects/cogs/issue.py
+++ b/flux-projects/cogs/issue.py
@@ -1,0 +1,24 @@
+import discord
+from discord.ext import commands
+from discord.ext.commands.cooldowns import BucketType
+from discord.utils import get
+
+
+class Issue(commands.Cog):
+
+    def __init__(self, flux):
+        self.flux = flux
+        self.question = self.flux.get_cog('Question')
+
+    @commands.command(brief='Create a new issue for DigiPol', help='Create a new issue for the app. You will be prompted to answer some questions by the bot.')
+    @commands.max_concurrency(1, per=BucketType.user, wait=False)
+    @commands.has_role('Flux Vetted')
+    async def issue(self, ctx):
+        await ctx.message.delete()
+
+        embed = discord.Embed(description='You\'re now creating a new issue for the app, here is what I need to know from you:', colour=discord.Colour.green())
+        await ctx.author.send(embed=embed)
+
+
+def setup(flux):
+    flux.add_cog(Issue(flux))

--- a/flux-projects/cogs/issue.py
+++ b/flux-projects/cogs/issue.py
@@ -19,6 +19,15 @@ class Issue(commands.Cog):
         embed = discord.Embed(description='You\'re now creating a new issue for the app, here is what I need to know from you:', colour=discord.Colour.green())
         await ctx.author.send(embed=embed)
 
+        questions = [['text', 'What is the title if your issue?', 64],
+                    ['date', 'What is the start date of your issue?'],
+                    ['date', 'What is the end date of your issue?'],
+                    ['text', 'What is the question of your issue?', 128],
+                    ['text', 'What is the description of your issue?', 256],
+                    ['text', 'What is the name of the sponsoring organisation?', 64]]
+        
+        ans = await self.question.question_handler(ctx.author, questions)
+
 
 def setup(flux):
     flux.add_cog(Issue(flux))

--- a/flux-projects/utility/config_manager.py
+++ b/flux-projects/utility/config_manager.py
@@ -9,7 +9,8 @@ def check():
         config = configparser.ConfigParser()
 
         config['Bot'] = {'token': 'token',
-                         'prefix': '!'}
+                         'prefix': '!',
+                         'issue_token': 'TEST'}
 
         config['Database'] = {'host': 'localhost',
                               'db': 'database',

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 aiohttp==3.6.2
 async-timeout==3.0.1
 attrs==19.3.0
+certifi==2020.4.5.2
 chardet==3.0.4
 configparser==5.0.0
 discord.py==1.3.3
@@ -8,6 +9,8 @@ idna==2.9
 multidict==4.7.6
 mysql-connector-python==8.0.20
 protobuf==3.12.2
+requests==2.23.0
 six==1.15.0
+urllib3==1.25.9
 websockets==8.1
 yarl==1.4.2


### PR DESCRIPTION
Allow users with the ~`Flux Vetted`~ `App Issue Creator` role in the Flux Discord to create a new issue for the app. (DigiPol)
Usage `!issue`
You will then be prompted with questions to answer about the issue. Including, title, start date, end date, question, description and sponsor.